### PR TITLE
Support empty prefix for minimal IDs

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -738,7 +738,10 @@ fn slugifyIssue(allocator: Allocator, storage: *Storage, prefix: []const u8, old
         hex_suffix = &hex_buf;
     }
 
-    const new_id = try std.fmt.allocPrint(allocator, "{s}-{s}-{s}", .{ prefix, slug, hex_suffix });
+    const new_id = if (prefix.len == 0)
+        try std.fmt.allocPrint(allocator, "{s}-{s}", .{ slug, hex_suffix })
+    else
+        try std.fmt.allocPrint(allocator, "{s}-{s}-{s}", .{ prefix, slug, hex_suffix });
     defer allocator.free(new_id);
 
     // Skip if already slugified (same ID)

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -833,9 +833,17 @@ pub fn generateIdWithTitle(allocator: Allocator, prefix: []const u8, title: ?[]c
     if (title) |t| {
         const slug = try slugify(allocator, t);
         defer allocator.free(slug);
-        return std.fmt.allocPrint(allocator, "{s}-{s}-{s}", .{ prefix, slug, hex });
+        if (prefix.len == 0) {
+            return std.fmt.allocPrint(allocator, "{s}-{s}", .{ slug, hex });
+        } else {
+            return std.fmt.allocPrint(allocator, "{s}-{s}-{s}", .{ prefix, slug, hex });
+        }
     } else {
-        return std.fmt.allocPrint(allocator, "{s}-{s}", .{ prefix, hex });
+        if (prefix.len == 0) {
+            return std.fmt.allocPrint(allocator, "{s}", .{hex});
+        } else {
+            return std.fmt.allocPrint(allocator, "{s}-{s}", .{ prefix, hex });
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Add support for `prefix=` (empty) in `.dots/config` to produce minimal IDs
- Handle empty prefix in `generateIdWithTitle()` and `slugifyIssue()`
- Add comprehensive tests for empty prefix behavior

## Problem

Users who want minimal IDs without a project prefix (e.g., `fix-auth-a1b2c3d4` instead of `myproject-fix-auth-a1b2c3d4`) have no clean option. This is useful for single-project repos where the prefix is redundant.

## Solution

1. In `storage.zig`: Handle empty prefix in `generateIdWithTitle()`
   - With title: produces `slug-hex` instead of `-slug-hex`
   - Without title: produces `hex` instead of `-hex`

2. In `main.zig`: Handle empty prefix in `slugifyIssue()`
   - Produces `slug-hex` instead of `-slug-hex` when prefix is empty

3. Add tests for all combinations and migration scenarios

Closes #10

---

**Disclosure:** This feature was implemented with AI assistance (Claude Code).